### PR TITLE
testing the args instead of using calledWith

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Shweta Sabne <shwetasabne@gmail.com> (http://www.shwetasabne.com)",
   "license": "ISC",
   "dependencies": {
-    "boom": "^4.0.0",
+    "boom": "^4.3.1",
     "bunyan": "^1.8.1",
     "bunyan-middleware": "^0.4.0",
     "config": "^1.21.0",

--- a/test/unit/middlewares/errorHandler.js
+++ b/test/unit/middlewares/errorHandler.js
@@ -20,11 +20,11 @@ describe('#errorHandler', () => {
     const err = new Error('bad error');
     errorHandler(err, req, res, undefined);
     expect(resJsonSpy.callCount).to.be.equal(1);
-    expect(resJsonSpy.calledWith({
+    expect(resJsonSpy.getCall(0).args[0]).to.deep.equal({
       statusCode: 400,
       error: 'Bad Request',
       message: 'Error: bad error'
-    })).to.be.equal(true);
+    });
   });
 
   it('should boomify 404 error', () => {
@@ -36,11 +36,11 @@ describe('#errorHandler', () => {
     const err = new Error('bad error');
     errorHandler(err, req, res, undefined);
     expect(resJsonSpy.callCount).to.be.equal(1);
-    expect(resJsonSpy.calledWith({
+    expect(resJsonSpy.getCall(0).args[0]).to.deep.equal({
       statusCode: 404,
       error: 'Not Found',
       message: 'Error: bad error'
-    })).to.be.equal(true);
+    });
   });
 
   it('should boomify 500 error', () => {
@@ -52,10 +52,10 @@ describe('#errorHandler', () => {
     const err = new Error('bad error');
     errorHandler(err, req, res, undefined);
     expect(resJsonSpy.callCount).to.be.equal(1);
-    expect(resJsonSpy.calledWith({
+    expect(resJsonSpy.getCall(0).args[0]).to.deep.equal({
       statusCode: 500,
       error: 'Internal Server Error',
       message: 'An internal server error occurred'
-    })).to.be.equal(true);
+    });
   });
 });

--- a/test/unit/middlewares/errorHandler.js
+++ b/test/unit/middlewares/errorHandler.js
@@ -23,7 +23,7 @@ describe('#errorHandler', () => {
     expect(resJsonSpy.getCall(0).args[0]).to.deep.equal({
       statusCode: 400,
       error: 'Bad Request',
-      message: 'Error: bad error'
+      message: 'bad error'
     });
   });
 
@@ -39,7 +39,7 @@ describe('#errorHandler', () => {
     expect(resJsonSpy.getCall(0).args[0]).to.deep.equal({
       statusCode: 404,
       error: 'Not Found',
-      message: 'Error: bad error'
+      message: 'bad error'
     });
   });
 


### PR DESCRIPTION
to see the diff instead of false vs true

before

```
AssertionError: expected false to equal true
      + expected - actual

      -false
      +true
```

after
```
 {
         "error": "Bad Request"
      -  "message": "bad error"
      +  "message": "Error: bad error"
         "statusCode": 400
       }
```